### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/Reportr.Data.Csv/Reportr.Data.Csv.csproj
+++ b/src/Reportr.Data.Csv/Reportr.Data.Csv.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Data.Dapper/Reportr.Data.Dapper.csproj
+++ b/src/Reportr.Data.Dapper/Reportr.Data.Dapper.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Data.Entity/Reportr.Data.Entity.csproj
+++ b/src/Reportr.Data.Entity/Reportr.Data.Entity.csproj
@@ -18,7 +18,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<None Remove="Icon.ico" />
 	</ItemGroup>

--- a/src/Reportr.Data.Json/Reportr.Data.Json.csproj
+++ b/src/Reportr.Data.Json/Reportr.Data.Json.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Data.Sql/Reportr.Data.Sql.csproj
+++ b/src/Reportr.Data.Sql/Reportr.Data.Sql.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Data.Xml/Reportr.Data.Xml.csproj
+++ b/src/Reportr.Data.Xml/Reportr.Data.Xml.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Integrations.Autofac/Reportr.Integrations.Autofac.csproj
+++ b/src/Reportr.Integrations.Autofac/Reportr.Integrations.Autofac.csproj
@@ -18,7 +18,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<None Remove="Icon.ico" />
 	</ItemGroup>

--- a/src/Reportr.Integrations.NCalc/Reportr.Integrations.NCalc.csproj
+++ b/src/Reportr.Integrations.NCalc/Reportr.Integrations.NCalc.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Integrations.Nettle/Reportr.Integrations.Nettle.csproj
+++ b/src/Reportr.Integrations.Nettle/Reportr.Integrations.Nettle.csproj
@@ -18,7 +18,15 @@
       <license type="MIT" />
     </metadata>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Remove="Icon.ico" />
   </ItemGroup>

--- a/src/Reportr.Integrations.Razor/Reportr.Integrations.Razor.csproj
+++ b/src/Reportr.Integrations.Razor/Reportr.Integrations.Razor.csproj
@@ -19,7 +19,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<None Remove="Icon.ico" />

--- a/src/Reportr.Registration.EF6/Reportr.Registration.EF6.csproj
+++ b/src/Reportr.Registration.EF6/Reportr.Registration.EF6.csproj
@@ -18,7 +18,15 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<None Remove="Icon.ico" />
 	</ItemGroup>

--- a/src/Reportr.Registration.Entity/Reportr.Registration.Entity.csproj
+++ b/src/Reportr.Registration.Entity/Reportr.Registration.Entity.csproj
@@ -18,7 +18,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 	  <Compile Remove="Migrations\**" />
 	  <EmbeddedResource Remove="Migrations\**" />

--- a/src/Reportr.Registration/Reportr.Registration.csproj
+++ b/src/Reportr.Registration/Reportr.Registration.csproj
@@ -18,7 +18,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<None Remove="Icon.ico" />
 	</ItemGroup>

--- a/src/Reportr/Reportr.csproj
+++ b/src/Reportr/Reportr.csproj
@@ -22,7 +22,16 @@
 			<license type="MIT" />
 		</metadata>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<None Remove="Icon.ico" />
 	</ItemGroup>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
